### PR TITLE
Visibility timeout heartbeat feature

### DIFF
--- a/v2/brokers/sqs/sqs.go
+++ b/v2/brokers/sqs/sqs.go
@@ -219,7 +219,9 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	// and leave the message in the queue
 	if !b.IsTaskRegistered(sig.Name) {
 		if sig.IgnoreWhenTaskNotRegistered {
-			b.deleteOne(delivery)
+			if err := b.deleteOne(delivery); err != nil {
+				log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, err)
+			}
 		}
 		return fmt.Errorf("task %s is not registered", sig.Name)
 	}
@@ -227,7 +229,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	err := taskProcessor.Process(sig)
 	if err != nil {
 		// stop task deletion in case we want to send messages to dlq in sqs
-		if err == errs.ErrStopTaskDeletion {
+		if errors.Is(err, errs.ErrStopTaskDeletion) {
 			return nil
 		}
 		return err
@@ -270,9 +272,8 @@ func (b *Broker) receiveMessage(qURL *string) (*awssqs.ReceiveMessageOutput, err
 	if b.GetConfig().SQS != nil {
 		waitTimeSeconds = b.GetConfig().SQS.WaitTimeSeconds
 		visibilityTimeout = b.GetConfig().SQS.VisibilityTimeout
-	} else {
-		waitTimeSeconds = 0
 	}
+
 	input := &awssqs.ReceiveMessageInput{
 		AttributeNames: []*string{
 			aws.String(awssqs.MessageSystemAttributeNameSentTimestamp),
@@ -348,6 +349,36 @@ func (b *Broker) continueReceivingMessages(qURL *string, deliveries chan *awssqs
 		go func() { deliveries <- output }()
 	}
 	return true, nil
+}
+
+// heartbeat is a method sends a heartbeat signal to AWS SQS to keep a message invisible to other consumers while being processed.
+func (b *Broker) heartbeat(delivery *awssqs.ReceiveMessageOutput, notify <-chan struct{}) {
+	ticker := time.NewTicker(time.Duration(*b.GetConfig().SQS.VisibilityTimeout) / 2 * time.Second)
+
+	go func() {
+		for {
+			select {
+			case <-notify:
+				ticker.Stop()
+
+				return
+			case <-b.stopReceivingChan:
+				ticker.Stop()
+
+				return
+			case <-ticker.C:
+				// Extend the delivery visibility timeout
+				_, err := b.service.ChangeMessageVisibility(&awssqs.ChangeMessageVisibilityInput{
+					QueueUrl:          b.defaultQueueURL(),
+					ReceiptHandle:     delivery.Messages[0].ReceiptHandle,
+					VisibilityTimeout: aws.Int64(int64(*b.GetConfig().SQS.VisibilityTimeout)),
+				})
+				if err != nil {
+					log.ERROR.Printf("Error when changing delivery visibility: %v", err)
+				}
+			}
+		}
+	}()
 }
 
 // stopReceiving is a method sending a signal to stopReceivingChan

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -3,12 +3,12 @@ package config
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"strings"
 	"time"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -97,11 +97,14 @@ type DynamoDBConfig struct {
 
 // SQSConfig wraps SQS related configuration
 type SQSConfig struct {
-	Client          *sqs.SQS
+	Client          sqsiface.SQSAPI
 	WaitTimeSeconds int `yaml:"receive_wait_time_seconds" envconfig:"SQS_WAIT_TIME_SECONDS"`
 	// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
 	// visibility timeout should default to nil to use the overall visibility timeout for the queue
 	VisibilityTimeout *int `yaml:"receive_visibility_timeout" envconfig:"SQS_VISIBILITY_TIMEOUT"`
+	// https://docs.aws.amazon.com/es_es/AWSSimpleQueueService/latest/SQSDeveloperGuide/best-practices-processing-messages-timely-manner.html
+	// visibility heartbeat should default to true to ensure that the visibility timeout is extended while the task is being processed.
+	VisibilityHeartBeat bool `yaml:"visibility_hearth_beat" envconfig:"SQS_VISIBILITY_HEARTBEAT"`
 }
 
 // RedisConfig ...

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.9.0
 	github.com/redis/go-redis/v9 v9.0.5
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli v1.22.5
 	go.mongodb.org/mongo-driver v1.17.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -223,6 +223,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -232,6 +234,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=


### PR DESCRIPTION
This PR aims to add a heartbeat feature in order to extend the AWS SQS visibility timeout periodically at half visibility timeout period in order to avoid consuming duplicated messages due to a long-running tasks above visibility period.